### PR TITLE
Make tonic-prometheus-layer compatible with latest tonic v0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/blkmlk/tonic-prometheus-layer"
 readme = "README.md"
 
 [dependencies]
-tonic = "0.11.0"
-tower = "0.4.13"
+tonic = "0.12"
+tower = "0.5"
 log = "0.4.21"
 pin-project = "1.1.5"
 once_cell = "1.19.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,9 +118,9 @@ pub struct MetricsService<S> {
     service: S,
 }
 
-impl<S> Service<request::Request<transport::Body>> for MetricsService<S>
+impl<S, B> Service<request::Request<B>> for MetricsService<S>
 where
-    S: Service<request::Request<transport::Body>>,
+    S: Service<request::Request<B>>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -130,7 +130,7 @@ where
         self.service.poll_ready(cx)
     }
 
-    fn call(&mut self, req: request::Request<transport::Body>) -> Self::Future {
+    fn call(&mut self, req: request::Request<B>) -> Self::Future {
         let method = req.method().to_string();
         let path = req.uri().path().to_owned();
         let f = self.service.call(req);


### PR DESCRIPTION
An incompatibility was introduced in this commit:
https://github.com/hyperium/tonic/commit/9c1f2f9402d97cfa4c9d9065b5af2fb99d2ef521 wherein the type inside the Response of the Service trait was changed:

-        type Response = hyper::Response<Body>;
+        type Response = hyper::Response<tonic::body::BoxBody>;

leading to this error:

error[E0277]: the trait bound `MetricsService<Routes>: tower::Service<hyper::Request<UnsyncBoxBody<hyper::body::Bytes, Status>>>` is not satisfied

We do not care about the body inside the request at all, so just make it a parameter so that we are compatible with anything.