### PR TITLE
Add improved and more compatible versions of the same metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 A lightweight Prometheus metrics layer for Tonic gRPC Server inspired by [autometrics](https://github.com/autometrics-dev/autometrics-rs)
 
 It provides the following metrics:
-* **Counter** for tracking the total number of function calls
-* **Histogram** for tracking function call duration
-* **Gauge** for tracking the number of concurrent function calls
+* `grpc_server_handled_total`: a **Counter** for tracking the total number of
+  completed gRPC calls.
+* `grpc_server_started_total`: a **Counter** for tracking the total number of
+  gRPC calls started. The difference between this and
+  `grpc_server_handled_total` equals the number of ongoing requests.
+* `grpc_server_handling_seconds`: a **Histogram** for tracking gRPC call
+  duration.
 
 ## Usage
 


### PR DESCRIPTION
The new metrics have the following advantages over the old ones:

- They are named "grpc" instead of "function_calls", which is more accurate.
- They have "server" in the name, allowing them to be distinguished from similar "client" counterparts which might be added in the future.
- They break out RPC counts by gRPC result status code, giving the ability for monitoring rules to tell the difference between successes and failures, alert on success thresholds, visualise an idea of the reasons for failures, etc...
- Their names match the ones used by a popular Go library, meaning that a single set of Prometheus rules can be applied broadly across both Rust and Go servers. Note however that we lack the "grpc_type" label because I could not find an easy way to get the data. It is meant to categorise requests as unary, client_stream, server_stream, or bidi_stream.

Note that we drop the old label called "method", which is the HTTP method. It is not important in the gRPC protocol (indeed it is always POST). The "grpc_method" label, for the gRPC method name, is not to be confused with it.

The old metrics are not deleted, as some existing users might depend on them. They could be deleted in a later version bump, though.