### PR TITLE
Bump dependency versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic_prometheus_layer"
-version = "0.1.11"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://github.com/blkmlk/tonic-prometheus-layer"
 license = "MIT"
@@ -11,13 +11,13 @@ repository = "https://github.com/blkmlk/tonic-prometheus-layer"
 readme = "README.md"
 
 [dependencies]
-tonic = "0.12"
+tonic = "0.13"
 tower = "0.5"
 pin-project = "1.1.5"
 once_cell = "1.19.0"
-prometheus = "0.13.4"
-thiserror = "1.0.61"
+prometheus = "0.14.0"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 tokio = { version = "1.40", features = ["macros", "rt-multi-thread"] }
-tonic-health = "0.12"
+tonic-health = "0.13"

--- a/src/client.rs
+++ b/src/client.rs
@@ -40,7 +40,7 @@ where
 
         let started_at = this.started_at.get_or_insert_with(|| {
             CLIENT_COUNTER_STARTED
-                .with_label_values(&[this.service, this.method])
+                .with_label_values(&[this.service.as_str(), this.method.as_str()])
                 .inc();
             Instant::now()
         });
@@ -55,10 +55,18 @@ where
             let code_str = format!("{:?}", code);
             let elapsed = Instant::now().duration_since(*started_at).as_secs_f64();
             CLIENT_COUNTER_HANDLED
-                .with_label_values(&[this.service, this.method, &code_str])
+                .with_label_values(&[
+                    this.service.as_str(),
+                    this.method.as_str(),
+                    code_str.as_str(),
+                ])
                 .inc();
             CLIENT_HISTOGRAM
-                .with_label_values(&[this.service, this.method, &code_str])
+                .with_label_values(&[
+                    this.service.as_str(),
+                    this.method.as_str(),
+                    code_str.as_str(),
+                ])
                 .observe(elapsed);
             Poll::Ready(v)
         } else {
@@ -123,7 +131,7 @@ mod tests {
 
     #[tokio::test]
     async fn simple() {
-        let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+        let (health_reporter, health_service) = tonic_health::server::health_reporter();
         health_reporter
             .set_service_status("yes", tonic_health::ServingStatus::Serving)
             .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,9 @@ where
         };
 
         let started_at = this.started_at.get_or_insert_with(|| {
-            GAUGE_MP.with_label_values(&[this.method, this.path]).inc();
+            GAUGE_MP
+                .with_label_values(&[this.method.as_str(), this.path.as_str()])
+                .inc();
             COUNTER_SM
                 .with_label_values(&[rpc_service, rpc_method])
                 .inc();
@@ -241,18 +243,20 @@ where
             let code_str = format!("{:?}", code);
             let elapsed = Instant::now().duration_since(*started_at).as_secs_f64();
             COUNTER_MP
-                .with_label_values(&[this.method, this.path])
+                .with_label_values(&[this.method.as_str(), this.path.as_str()])
                 .inc();
             COUNTER_SMC
-                .with_label_values(&[rpc_service, rpc_method, &code_str])
+                .with_label_values(&[rpc_service, rpc_method, code_str.as_str()])
                 .inc();
             HISTOGRAM_MP
-                .with_label_values(&[this.method, this.path])
+                .with_label_values(&[this.method.as_str(), this.path.as_str()])
                 .observe(elapsed);
             HISTOGRAM_SMC
-                .with_label_values(&[rpc_service, rpc_method, &code_str])
+                .with_label_values(&[rpc_service, rpc_method, code_str.as_str()])
                 .observe(elapsed);
-            GAUGE_MP.with_label_values(&[this.method, this.path]).dec();
+            GAUGE_MP
+                .with_label_values(&[this.method.as_str(), this.path.as_str()])
+                .dec();
 
             Poll::Ready(v)
         } else {


### PR DESCRIPTION
This is mostly because prometheus 0.13 is vulnerable to https://rustsec.org/advisories/RUSTSEC-2024-0437 as reported in https://github.com/vandry/comprehensive/issues/2
but at the same time we can keep up with the latest version of tonic.

This requires bumping our own minor version because dependent crates must follow the same versions of tonic and prometheus.